### PR TITLE
docs(publications): reverse order newest-first, add CHEP 2024 and Springer 2024 papers

### DIFF
--- a/docs/source/publications/publications.rst
+++ b/docs/source/publications/publications.rst
@@ -8,29 +8,15 @@ Selected Publications
 
 |br|
 
-2016
+2025
 ==============
-`ATLAS WORLD-cloud and networking in PanDA <https://iopscience.iop.org/article/10.1088/1742-6596/898/5/052011>`_, CHEP 2016
+`Modernizing ATLAS PanDA for a sustainable multi-experiment future <https://doi.org/10.1051/epjconf/202533701108>`_, CHEP 2024
 
-`PanDA for ATLAS distributed computing in the next decade <https://iopscience.iop.org/article/10.1088/1742-6596/898/5/052002>`_, CHEP 2016
-
-2018
+2024
 ==============
-`ATLAS Global Shares implementation in PanDA <https://doi.org/10.1051/epjconf/201921403025>`_, CHEP 2018
+`PanDA: Production and Distributed Analysis System <https://doi.org/10.1007/s41781-024-00114-3>`_, Computing and Software for Big Science
 
-`The future of distributed computing systems in ATLAS: Boldly venturing beyond grids <https://doi.org/10.1051/epjconf/201921403047>`_, CHEP 2018
-
-`Harvester : an edge service harvesting heterogeneous resources for ATLAS <https://doi.org/10.1051/epjconf/201921403030>`_, CHEP 2018
-
-`The Data Ocean project : An ATLAS and Google R&D collaboration <https://doi.org/10.1051/epjconf/201921404020>`_, CHEP 2018
-
-`BigPanDA: PanDA Workload Management System and its Applications beyond ATLAS <https://doi.org/10.1051/epjconf/201921403050>`_, CHEP 2018
-
-2019
-==============
-`Managing the ATLAS Grid through Harvester <https://doi.org/10.1051/epjconf/202024503010>`_, CHEP 2019
-
-`Using Kubernetes as an ATLAS computing site <https://doi.org/10.1051/epjconf/202024507025>`_, CHEP 2019
+`Operational Experience and R&D results using the Google Cloud for High Energy Physics in the ATLAS experiment <https://arxiv.org/abs/2403.15873>`_, arXiv and International Journal of Modern Physics A
 
 2023
 ==============
@@ -44,8 +30,26 @@ Selected Publications
 
 `Accelerating science: The usage of commercial clouds in ATLAS Distributed Computing <https://doi.org/10.1051/epjconf/202429507002>`_, CHEP 2023
 
-`PanDA: Production and Distributed Analysis System <https://doi.org/10.1007/s41781-024-00114-3>`_, Journal of Computing and Software for Big Science
-
-2024
+2019
 ==============
-`Operational Experience and R&D results using the Google Cloud for High Energy Physics in the ATLAS experiment <https://arxiv.org/abs/2403.15873>`_, arXiv and International Journal of Modern Physics A
+`Managing the ATLAS Grid through Harvester <https://doi.org/10.1051/epjconf/202024503010>`_, CHEP 2019
+
+`Using Kubernetes as an ATLAS computing site <https://doi.org/10.1051/epjconf/202024507025>`_, CHEP 2019
+
+2018
+==============
+`ATLAS Global Shares implementation in PanDA <https://doi.org/10.1051/epjconf/201921403025>`_, CHEP 2018
+
+`The future of distributed computing systems in ATLAS: Boldly venturing beyond grids <https://doi.org/10.1051/epjconf/201921403047>`_, CHEP 2018
+
+`Harvester : an edge service harvesting heterogeneous resources for ATLAS <https://doi.org/10.1051/epjconf/201921403030>`_, CHEP 2018
+
+`The Data Ocean project : An ATLAS and Google R&D collaboration <https://doi.org/10.1051/epjconf/201921404020>`_, CHEP 2018
+
+`BigPanDA: PanDA Workload Management System and its Applications beyond ATLAS <https://doi.org/10.1051/epjconf/201921403050>`_, CHEP 2018
+
+2016
+==============
+`ATLAS WORLD-cloud and networking in PanDA <https://iopscience.iop.org/article/10.1088/1742-6596/898/5/052011>`_, CHEP 2016
+
+`PanDA for ATLAS distributed computing in the next decade <https://iopscience.iop.org/article/10.1088/1742-6596/898/5/052002>`_, CHEP 2016


### PR DESCRIPTION
## Summary
- Reverse publication order so newest entries appear at the top
- Add new 2025 section with CHEP 2024 paper: *Modernizing ATLAS PanDA for a sustainable multi-experiment future* (EPJ Web of Conferences)
- Move *PanDA: Production and Distributed Analysis System* (Springer) from 2023 to its correct year 2024