### PR TITLE
Add JSON ART header examples and warn against outer single quotes

### DIFF
--- a/docs/source/advanced/brokerage.rst
+++ b/docs/source/advanced/brokerage.rst
@@ -476,6 +476,22 @@ Examples in ART test headers:
    # any NVIDIA GPU excluding P100 and V100
    prun --architecture '{"gpu_spec": {"vendor": "nvidia", "model": {"pattern": ".*(P100|V100).*", "excl": true}}}'
 
+Examples in ART test headers (JSON format):
+
+.. code-block:: bash
+
+   # any NVIDIA GPU with at least 40 GB VRAM and CUDA >= 12.0
+   # art-architecture: {"gpu_spec": {"vendor": "nvidia", "vram": ">=40960", "version": ">=12.0"}}
+
+   # any NVIDIA GPU excluding P100 and V100
+   # art-architecture: {"gpu_spec": {"vendor": "nvidia", "model": {"pattern": ".*(P100|V100).*", "excl": true}}}
+
+.. warning::
+   ART passes the ``art-architecture`` header value **literally** to prun — unlike the shell command line where
+   surrounding quotes are stripped. Do **not** wrap the JSON in single quotes in the header. Using
+   ``# art-architecture: '{"gpu_spec": ...}'`` will cause prun to receive a string starting with ``'``,
+   which silently fails JSON parsing and results in the test appearing as *missing* rather than *failed*.
+
 .. note::
    For model exclusion, ``pattern`` and ``excl`` must be nested inside ``model`` as a dictionary. Placing them at the top level of ``gpu_spec`` will silently have no effect. The regex follows Python ``re.match`` semantics and is case-insensitive, so ``.*(P100|V100).*`` correctly matches both ``Tesla V100S-PCIE-32GB`` and ``Tesla P100-PCIE-16GB``.
 


### PR DESCRIPTION
## Summary

Adds JSON format examples for `art-architecture` ART test headers, and a warning explaining why outer single quotes must not be used.

The existing docs already showed correct `prun --architecture '...'` usage (shell strips the quotes), but had no JSON examples for the ART header case. A real test (`test_trf_simGPU_adept.sh` in athena MR !88199) was broken because the JSON was wrapped in single quotes — ART passes the value literally to prun, so the quotes were included and JSON parsing silently failed. The test appeared as *missing* rather than *failed* for 3 nightlies.

The warning also explains why the previous shorthand format worked with the same quoting style: the shorthand parser does a substring search for `#&` anywhere in the string, so the leading `'` was harmlessly ignored.

Fix for the athena test itself: https://gitlab.cern.ch/atlas/athena/-/merge_requests/88249