### PR TITLE
Add JSON format equivalent to the prun GPU full container image example

### DIFF
--- a/docs/source/client/prun.rst
+++ b/docs/source/client/prun.rst
@@ -253,18 +253,60 @@ like renaming and stage-out.
 Running on GPU
 --------------------
 
-GPUs (Graphics Processing Unit) have numerous advantages in data-intensive tasks, 
-physics analysis, machine learning, and other fields, making them powerful tools for 
+GPUs (Graphics Processing Unit) have numerous advantages in data-intensive tasks,
+physics analysis, machine learning, and other fields, making them powerful tools for
 high-performance and efficient calculations and processing.
 
-GPU resources are available exclusively at designated sites, necessitating explicit job assignment. 
-Users need to specify the GPU architecture in the ``--architecture`` option when executing ``prun``.
-The option's argument is explained in `this section <../advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware>`__.
-For example, to utilize NVIDIA GPUs, you can set the argument like: ``--architecture '&nvidia'``.　e.g.,
+GPU resources are available exclusively at designated sites, necessitating explicit job assignment.
+Users need to specify the GPU requirements in the ``--architecture`` option when executing ``prun``.
+Full documentation of the option is available in `this section <../advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware>`__.
+
+**Shorthand format**
+
+The shorthand format covers the most common cases: vendor selection and simple attribute filters
+such as minimum VRAM, CUDA version, microarchitecture, and GPU model inclusion.
 
 .. prompt:: bash
 
- prun --containerImage docker://gitlab-registry.cern.ch/hepimages/public/gpu-basic-test --exec "python /test-gpu.py" --outDS user.$USER.`uuidgen` --noBuild --nJobs=1 --architecture '&nvidia'
+ # Any NVIDIA GPU
+ prun ... --architecture '#&nvidia'
+
+ # NVIDIA GPU with at least 40 GB VRAM
+ prun ... --architecture '#&nvidia:vram>=40960'
+
+ # NVIDIA A100 on Ampere microarchitecture with CUDA >= 12.0
+ prun ... --architecture '#&nvidia:model=.*A100.*:uarch=Ampere:cuda>=12.0'
+
+**JSON format**
+
+The JSON format supports all shorthand filters and additionally allows **model exclusion**
+(e.g. excluding specific GPU generations). It is required when you need to exclude certain models.
+
+.. prompt:: bash
+
+ # Any NVIDIA GPU with at least 40 GB VRAM and CUDA >= 12.0
+ prun ... --architecture '{"gpu_spec": {"vendor": "nvidia", "vram": ">=40960", "version": ">=12.0"}}'
+
+ # Any NVIDIA GPU excluding P100 and V100
+ prun ... --architecture '{"gpu_spec": {"vendor": "nvidia", "model": {"pattern": ".*(P100|V100).*", "excl": true}}}'
+
+A full example using a container image:
+
+.. prompt:: bash
+
+ # Shorthand format
+ prun --containerImage docker://gitlab-registry.cern.ch/hepimages/public/gpu-basic-test \
+      --exec "python /test-gpu.py" \
+      --outDS user.$USER.`uuidgen` \
+      --noBuild --nJobs=1 \
+      --architecture '#&nvidia'
+
+ # Equivalent JSON format
+ prun --containerImage docker://gitlab-registry.cern.ch/hepimages/public/gpu-basic-test \
+      --exec "python /test-gpu.py" \
+      --outDS user.$USER.`uuidgen` \
+      --noBuild --nJobs=1 \
+      --architecture '{"gpu_spec": {"vendor": "nvidia"}}'
 ---------
 
 |br|

--- a/docs/source/client/prun.rst
+++ b/docs/source/client/prun.rst
@@ -259,42 +259,12 @@ high-performance and efficient calculations and processing.
 
 GPU resources are available exclusively at designated sites, necessitating explicit job assignment.
 Users need to specify the GPU requirements in the ``--architecture`` option when executing ``prun``.
-Full documentation of the option is available in `this section <../advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware>`__.
-
-**Shorthand format**
-
-The shorthand format covers the most common cases: vendor selection and simple attribute filters
-such as minimum VRAM, CUDA version, microarchitecture, and GPU model inclusion.
+Full documentation of the option, including all supported formats and filter attributes, is available in
+`this section <../advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware>`__.
 
 .. prompt:: bash
 
- # Any NVIDIA GPU
- prun ... --architecture '#&nvidia'
-
- # NVIDIA GPU with at least 40 GB VRAM
- prun ... --architecture '#&nvidia:vram>=40960'
-
- # NVIDIA A100 on Ampere microarchitecture with CUDA >= 12.0
- prun ... --architecture '#&nvidia:model=.*A100.*:uarch=Ampere:cuda>=12.0'
-
-**JSON format**
-
-The JSON format supports all shorthand filters and additionally allows **model exclusion**
-(e.g. excluding specific GPU generations). It is required when you need to exclude certain models.
-
-.. prompt:: bash
-
- # Any NVIDIA GPU with at least 40 GB VRAM and CUDA >= 12.0
- prun ... --architecture '{"gpu_spec": {"vendor": "nvidia", "vram": ">=40960", "version": ">=12.0"}}'
-
- # Any NVIDIA GPU excluding P100 and V100
- prun ... --architecture '{"gpu_spec": {"vendor": "nvidia", "model": {"pattern": ".*(P100|V100).*", "excl": true}}}'
-
-A full example using a container image:
-
-.. prompt:: bash
-
- # Shorthand format
+ # Shorthand format — any NVIDIA GPU
  prun --containerImage docker://gitlab-registry.cern.ch/hepimages/public/gpu-basic-test \
       --exec "python /test-gpu.py" \
       --outDS user.$USER.`uuidgen` \


### PR DESCRIPTION
The GPU section of the prun docs already documents both shorthand and JSON formats with dedicated examples. However, the "full example" block at the end only showed the shorthand variant. This PR adds an equivalent JSON example alongside it so users can see the complete command syntax for both formats in a runnable context.

No new information is introduced — the brokerage page remains the reference for full option details.